### PR TITLE
fix(docs): set correct persistence type in n8n storage example

### DIFF
--- a/docs/charts/n8n/storage.md
+++ b/docs/charts/n8n/storage.md
@@ -81,6 +81,7 @@ binaryData:
 main:
   persistence:
     enabled: true
+    type: dynamic
     volumeName: "n8n-binary-data"
     mountPath: "/home/node/.n8n"
     size: 10Gi


### PR DESCRIPTION
Update the storage.md example to explicitly set main.persistence.type: dynamic since the default is emptyDir, ensuring proper dynamic volume provisioning.