### PR TITLE
Grant privileges on public schema to mlflow_user

### DIFF
--- a/docs/charts/mlflow/postgresql-backend-installation.md
+++ b/docs/charts/mlflow/postgresql-backend-installation.md
@@ -54,6 +54,7 @@ Create a database and user for MLflow:
 CREATE DATABASE mlflow;
 CREATE USER mlflow_user WITH PASSWORD 'your_secure_password';
 GRANT ALL PRIVILEGES ON DATABASE mlflow TO mlflow_user;
+GRANT ALL PRIVILEGES ON SCHEMA public TO mlflow_user;
 ```
 
 ### 2. Install MLflow with External PostgreSQL


### PR DESCRIPTION
The chart installation expects the provided user (mlflow_user) to already have full CREATE schema privileges. Creating this PR to address the issue.

Fixes: #40 
Closes: #40 