### PR TITLE
Fix docs: Reference created Kubernetes secret in Basic Auth configuration example

### DIFF
--- a/docs/charts/mlflow/authentication-configuration.md
+++ b/docs/charts/mlflow/authentication-configuration.md
@@ -80,6 +80,10 @@ auth:
   enabled: true
   adminUsername: admin
   adminPassword: your-secure-password
+  existingAdminSecret:
+    name: "mlflow-auth"
+    usernameKey: "admin-user"
+    passwordKey: "admin-password"
   defaultPermission: READ
   appName: basic-auth
   authorizationFunction: mlflow.server.auth:authenticate_request_basic_auth


### PR DESCRIPTION
The “Create User Credentials Secret” section creates a Kubernetes secret, but the following “Configure Basic Authentication with Secret” example uses literal values instead of referencing the created secret.

This PR updates the docs to:

- explain that credentials come from the Kubernetes secret
- clarify how the secret values map to the Basic Auth configuration
- avoid confusion for users following the setup guide

**Why this is needed ?**

While following the guide, it appears that:

- A secret is created (mlflow-auth), but the next step does not show how that secret is actually used
- This may lead users to assume the secret is unused or misconfigured.
- The updated wording makes the flow explicit and consistent.